### PR TITLE
Updated facilitator API to populate country and sector fields

### DIFF
--- a/src/api/speaker/content-types/speaker/schema.json
+++ b/src/api/speaker/content-types/speaker/schema.json
@@ -16,7 +16,8 @@
       "enum": [
         "Shri",
         "Mr",
-        "Mrs"
+        "Mrs",
+        "Dr"
       ]
     },
     "fullName": {

--- a/src/api/speaker/controllers/speaker.js
+++ b/src/api/speaker/controllers/speaker.js
@@ -11,7 +11,14 @@ module.exports = createCoreController('api::speaker.speaker', ({ strapi }) => ({
     async find(ctx) {
         try {
           const entities = await strapi.entityService.findMany('api::speaker.speaker', {
-            populate: ['image'],
+            populate: {
+              image: {
+                fields: ['url'],
+              },
+              country: {
+                fields: ['country'],
+              },
+            },
             filters: ctx.query.filters,
             sort: ctx.query.sort,
             pagination: ctx.query.pagination,
@@ -33,7 +40,6 @@ module.exports = createCoreController('api::speaker.speaker', ({ strapi }) => ({
           console.error('Error fetching speakers:', error);
           return ctx.internalServerError('Failed to fetch speakers');
         }
-      }
-      
+      },      
 
 }));

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -547,7 +547,7 @@ export interface ApiSpeakerSpeaker extends Struct.CollectionTypeSchema {
     > &
       Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
-    salutation: Schema.Attribute.Enumeration<['Shri', 'Mr', 'Mrs']>;
+    salutation: Schema.Attribute.Enumeration<['Shri', 'Mr', 'Mrs', 'Dr']>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;


### PR DESCRIPTION
Updated `find`, `findOne`, and `create` methods in the facilitator controller.
- Populated `country` with only `name` and `countryCode`.
- Populated `sector` with only `name`.