### PR TITLE
Added WooCommerce order synch controller to Strapi via Webhook

### DIFF
--- a/src/api/facilitator/routes/facilitator.js
+++ b/src/api/facilitator/routes/facilitator.js
@@ -94,6 +94,15 @@ module.exports = {
         middlewares: [],
       },
     },
-
+    {
+      method: 'POST',
+      path: '/facilitators/wooOrderSync',
+      handler: 'facilitator.wooOrderSync',
+      config: {
+        policies: [],
+        middlewares: [],
+        auth: false
+      },
+    },
   ],
 };

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-05-20T08:52:12.438Z"
+    "x-generation-date": "2025-05-22T09:11:04.581Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -2961,6 +2961,87 @@
         ],
         "parameters": [],
         "operationId": "post/facilitators/verifyLoginOtp",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/FacilitatorRequest"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/facilitators/wooOrderSync": {
+      "post": {
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/FacilitatorResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Bad Request",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Unauthorized",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Forbidden",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not Found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Internal Server Error",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          }
+        },
+        "tags": [
+          "Facilitator"
+        ],
+        "parameters": [],
+        "operationId": "post/facilitators/wooOrderSync",
         "requestBody": {
           "required": true,
           "content": {


### PR DESCRIPTION
Added wooOrderSync controller to handle WooCommerce order webhook events.
- Verified and validated webhook signature for secure data intake.
- Checked if the corresponding facilitator exists in Strapi before applying updates.
- Parsed meta_data from WooCommerce order to extract:
  - totalAmount
  - GST breakdown: