### PR TITLE
Fix: used existing Cognito ID for facilitator-linked delegate creation

### DIFF
--- a/src/api/delegate/controllers/delegate.js
+++ b/src/api/delegate/controllers/delegate.js
@@ -89,6 +89,17 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
         });
   
         await client.send(setPasswordCommand);
+      }else {
+        // Fetch cognitoId from facilitator
+        const facilitator = await strapi.entityService.findOne('api::facilitator.facilitator', data.facilitatorId, {
+          fields: ['cognitoId'],
+        });
+      
+        if (!facilitator || !facilitator.cognitoId) {
+          return ctx.badRequest('Invalid facilitator or missing Cognito ID');
+        }
+      
+        cognitoId = facilitator.cognitoId;
       }
   
       // 5. Store initial delegate without confirmationId

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-05-27T19:16:52.880Z"
+    "x-generation-date": "2025-05-28T07:38:48.625Z"
   },
   "x-strapi-config": {
     "plugins": [


### PR DESCRIPTION
Resolved issue where delegates marked as facilitators were not assigned the correct Cognito ID. The flow now correctly fetches and uses the Cognito ID from the related facilitator instead of attempting Cognito registration.