### PR TITLE
Enhance login flow: delete incomplete users from Cognito and Strapi

### DIFF
--- a/src/api/facilitator/content-types/facilitator/schema.json
+++ b/src/api/facilitator/content-types/facilitator/schema.json
@@ -57,6 +57,10 @@
       "relation": "oneToMany",
       "target": "api::delegate.delegate",
       "mappedBy": "facilitatorId"
+    },
+    "passBought": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-05-29T06:22:11.224Z"
+    "x-generation-date": "2025-05-31T07:52:54.271Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -9737,6 +9737,9 @@
                   }
                 }
               },
+              "passBought": {
+                "type": "boolean"
+              },
               "createdAt": {
                 "type": "string",
                 "format": "date-time"
@@ -11092,6 +11095,9 @@
                   "example": "string or id"
                 }
               },
+              "passBought": {
+                "type": "boolean"
+              },
               "locale": {
                 "type": "string"
               },
@@ -11689,6 +11695,9 @@
                         }
                       }
                     },
+                    "passBought": {
+                      "type": "boolean"
+                    },
                     "createdAt": {
                       "type": "string",
                       "format": "date-time"
@@ -11812,6 +11821,9 @@
                 }
               }
             }
+          },
+          "passBought": {
+            "type": "boolean"
           },
           "createdAt": {
             "type": "string",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -626,6 +626,7 @@ export interface ApiFacilitatorFacilitator extends Struct.CollectionTypeSchema {
       'api::facilitator.facilitator'
     > &
       Schema.Attribute.Private;
+    passBought: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<false>;
     paymentMode: Schema.Attribute.String;
     paymentStatus: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;


### PR DESCRIPTION
Updated the login controller to improve handling of incomplete registrations:

- Fetches Cognito user and checks if the user is a delegate
- If no matching facilitator is found in Strapi, deletes the Cognito user and returns an error
- If the user is UNCONFIRMED or has not bought a pass (`passBought === false`), deletes both the Cognito user and facilitator record
- Ensures safe null checks before deletion
- Proceeds to initiate custom auth (OTP) only for valid, completed users