### PR TITLE
Fix facilitator creation flow with Cognito user cleanup and add email templates for forms

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "better-sqlite3": "11.3.0",
         "fs-extra": "^10.0.0",
         "mime-types": "^2.1.27",
+        "nodemailer": "^7.0.3",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
         "react-router-dom": "^6.0.0",
@@ -4256,6 +4257,77 @@
         "styled-components": "^6.0.0"
       }
     },
+    "node_modules/@strapi/admin/node_modules/@strapi/design-system": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.18.tgz",
+      "integrity": "sha512-/19KcoJd36smfVI1uBCFPDfhrDA5Z5kWJpJ5obdtXLwl+T5ktmrhUJ+ReuLztOK/zafxZj8BQmbHJ0CJGBgm4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.0.0-rc.18",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/admin/node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
+      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/admin/node_modules/axios": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.4.tgz",
@@ -4414,6 +4486,77 @@
         "styled-components": "^6.0.0"
       }
     },
+    "node_modules/@strapi/content-manager/node_modules/@strapi/design-system": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.18.tgz",
+      "integrity": "sha512-/19KcoJd36smfVI1uBCFPDfhrDA5Z5kWJpJ5obdtXLwl+T5ktmrhUJ+ReuLztOK/zafxZj8BQmbHJ0CJGBgm4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.0.0-rc.18",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/content-manager/node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
+      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/content-releases": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/@strapi/content-releases/-/content-releases-5.11.0.tgz",
@@ -4448,6 +4591,77 @@
         "styled-components": "^6.0.0"
       }
     },
+    "node_modules/@strapi/content-releases/node_modules/@strapi/design-system": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.18.tgz",
+      "integrity": "sha512-/19KcoJd36smfVI1uBCFPDfhrDA5Z5kWJpJ5obdtXLwl+T5ktmrhUJ+ReuLztOK/zafxZj8BQmbHJ0CJGBgm4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.0.0-rc.18",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/content-releases/node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
+      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/content-type-builder": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/@strapi/content-type-builder/-/content-type-builder-5.11.0.tgz",
@@ -4479,6 +4693,77 @@
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-router-dom": "^6.0.0",
         "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/content-type-builder/node_modules/@strapi/design-system": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.18.tgz",
+      "integrity": "sha512-/19KcoJd36smfVI1uBCFPDfhrDA5Z5kWJpJ5obdtXLwl+T5ktmrhUJ+ReuLztOK/zafxZj8BQmbHJ0CJGBgm4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.0.0-rc.18",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/content-type-builder/node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
+      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@strapi/content-type-builder/node_modules/fs-extra": {
@@ -4693,10 +4978,39 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
-    "node_modules/@strapi/design-system": {
+    "node_modules/@strapi/email": {
+      "version": "5.11.0",
+      "resolved": "https://registry.npmjs.org/@strapi/email/-/email-5.11.0.tgz",
+      "integrity": "sha512-kthYsnIPB9DIZaYWhBpcQyKKigEnCVujSHFexSUosXJQCY+eXjPnyw4RC1N6h+ILR/3lw/cXbKqKrlVsi8Qy9A==",
+      "dependencies": {
+        "@strapi/design-system": "2.0.0-rc.18",
+        "@strapi/icons": "2.0.0-rc.18",
+        "@strapi/provider-email-sendmail": "5.11.0",
+        "@strapi/utils": "5.11.0",
+        "koa2-ratelimit": "^1.1.3",
+        "lodash": "4.17.21",
+        "react-intl": "6.6.2",
+        "react-query": "3.39.3",
+        "yup": "0.32.9"
+      },
+      "engines": {
+        "node": ">=18.0.0 <=22.x.x",
+        "npm": ">=6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/admin": "^5.0.0",
+        "koa": "^2.15.2",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "react-router-dom": "^6.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/email/node_modules/@strapi/design-system": {
       "version": "2.0.0-rc.18",
       "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.18.tgz",
       "integrity": "sha512-/19KcoJd36smfVI1uBCFPDfhrDA5Z5kWJpJ5obdtXLwl+T5ktmrhUJ+ReuLztOK/zafxZj8BQmbHJ0CJGBgm4A==",
+      "license": "MIT",
       "dependencies": {
         "@codemirror/lang-json": "6.0.1",
         "@floating-ui/react-dom": "2.1.0",
@@ -4731,32 +5045,36 @@
         "styled-components": "^6.0.0"
       }
     },
-    "node_modules/@strapi/email": {
-      "version": "5.11.0",
-      "resolved": "https://registry.npmjs.org/@strapi/email/-/email-5.11.0.tgz",
-      "integrity": "sha512-kthYsnIPB9DIZaYWhBpcQyKKigEnCVujSHFexSUosXJQCY+eXjPnyw4RC1N6h+ILR/3lw/cXbKqKrlVsi8Qy9A==",
+    "node_modules/@strapi/email/node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
+      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
+      "license": "MIT",
       "dependencies": {
-        "@strapi/design-system": "2.0.0-rc.18",
-        "@strapi/icons": "2.0.0-rc.18",
-        "@strapi/provider-email-sendmail": "5.11.0",
-        "@strapi/utils": "5.11.0",
-        "koa2-ratelimit": "^1.1.3",
-        "lodash": "4.17.21",
-        "react-intl": "6.6.2",
-        "react-query": "3.39.3",
-        "yup": "0.32.9"
-      },
-      "engines": {
-        "node": ">=18.0.0 <=22.x.x",
-        "npm": ">=6.0.0"
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
       },
       "peerDependencies": {
-        "@strapi/admin": "^5.0.0",
-        "koa": "^2.15.2",
         "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0",
-        "react-router-dom": "^6.0.0",
-        "styled-components": "^6.0.0"
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@strapi/generators": {
@@ -4820,6 +5138,77 @@
         "styled-components": "^6.0.0"
       }
     },
+    "node_modules/@strapi/i18n/node_modules/@strapi/design-system": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.18.tgz",
+      "integrity": "sha512-/19KcoJd36smfVI1uBCFPDfhrDA5Z5kWJpJ5obdtXLwl+T5ktmrhUJ+ReuLztOK/zafxZj8BQmbHJ0CJGBgm4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.0.0-rc.18",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/i18n/node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
+      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/icons": {
       "version": "2.0.0-rc.18",
       "resolved": "https://registry.npmjs.org/@strapi/icons/-/icons-2.0.0-rc.18.tgz",
@@ -4878,6 +5267,77 @@
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-router-dom": "^6.0.0",
         "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/plugin-cloud/node_modules/@strapi/design-system": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.18.tgz",
+      "integrity": "sha512-/19KcoJd36smfVI1uBCFPDfhrDA5Z5kWJpJ5obdtXLwl+T5ktmrhUJ+ReuLztOK/zafxZj8BQmbHJ0CJGBgm4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.0.0-rc.18",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/plugin-cloud/node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
+      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@strapi/plugin-documentation": {
@@ -5368,6 +5828,77 @@
         "styled-components": "^6.0.0"
       }
     },
+    "node_modules/@strapi/plugin-users-permissions/node_modules/@strapi/design-system": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.18.tgz",
+      "integrity": "sha512-/19KcoJd36smfVI1uBCFPDfhrDA5Z5kWJpJ5obdtXLwl+T5ktmrhUJ+ReuLztOK/zafxZj8BQmbHJ0CJGBgm4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.0.0-rc.18",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/plugin-users-permissions/node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
+      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@strapi/provider-email-sendmail": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/@strapi/provider-email-sendmail/-/provider-email-sendmail-5.11.0.tgz",
@@ -5435,6 +5966,77 @@
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-router-dom": "^6.0.0",
         "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/review-workflows/node_modules/@strapi/design-system": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.18.tgz",
+      "integrity": "sha512-/19KcoJd36smfVI1uBCFPDfhrDA5Z5kWJpJ5obdtXLwl+T5ktmrhUJ+ReuLztOK/zafxZj8BQmbHJ0CJGBgm4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.0.0-rc.18",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/review-workflows/node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
+      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@strapi/strapi": {
@@ -5603,6 +6205,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
       "integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
+      "license": "Apache-2.0",
       "peer": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -5640,37 +6243,6 @@
       },
       "engines": {
         "node": ">=14.14"
-      }
-    },
-    "node_modules/@strapi/ui-primitives": {
-      "version": "2.0.0-rc.18",
-      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
-      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
-      "dependencies": {
-        "@radix-ui/number": "1.0.1",
-        "@radix-ui/primitive": "1.0.1",
-        "@radix-ui/react-collection": "1.0.3",
-        "@radix-ui/react-compose-refs": "1.0.1",
-        "@radix-ui/react-context": "1.0.1",
-        "@radix-ui/react-direction": "1.0.1",
-        "@radix-ui/react-dismissable-layer": "1.0.5",
-        "@radix-ui/react-focus-guards": "1.0.1",
-        "@radix-ui/react-focus-scope": "1.0.4",
-        "@radix-ui/react-id": "1.0.1",
-        "@radix-ui/react-popper": "1.1.3",
-        "@radix-ui/react-portal": "1.0.4",
-        "@radix-ui/react-primitive": "1.0.3",
-        "@radix-ui/react-slot": "1.0.2",
-        "@radix-ui/react-use-controllable-state": "1.0.1",
-        "@radix-ui/react-use-layout-effect": "1.0.1",
-        "@radix-ui/react-use-previous": "1.0.1",
-        "@radix-ui/react-visually-hidden": "1.0.3",
-        "aria-hidden": "1.2.4",
-        "react-remove-scroll": "2.5.10"
-      },
-      "peerDependencies": {
-        "react": "^17.0.0 || ^18.0.0",
-        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@strapi/upload": {
@@ -5713,6 +6285,77 @@
         "react-dom": "^17.0.0 || ^18.0.0",
         "react-router-dom": "^6.0.0",
         "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@strapi/design-system": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.18.tgz",
+      "integrity": "sha512-/19KcoJd36smfVI1uBCFPDfhrDA5Z5kWJpJ5obdtXLwl+T5ktmrhUJ+ReuLztOK/zafxZj8BQmbHJ0CJGBgm4A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.0.0-rc.18",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
+    "node_modules/@strapi/upload/node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.18",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.18.tgz",
+      "integrity": "sha512-XCXZ/IqOSn5x4UhbP/+xaWG8ZACEpgk0Ov/SarC0BH3TbA4vqaY/SDVFNQwwZQcjT9YnNndZCJW0Axwq5C9xPw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@strapi/upload/node_modules/fs-extra": {
@@ -13193,6 +13836,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/nodemailer": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-7.0.3.tgz",
+      "integrity": "sha512-Ajq6Sz1x7cIK3pN6KesGTah+1gnwMnx5gKl3piQlQQE/PwyJ4Mbc8is2psWYxK3RJTVeqsDaCv8ZzXLCDHMTZw==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
       }
     },
     "node_modules/nodemailer-fetch": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "better-sqlite3": "11.3.0",
     "fs-extra": "^10.0.0",
     "mime-types": "^2.1.27",
+    "nodemailer": "^7.0.3",
     "react": "^18.0.0",
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.0.0",

--- a/src/api/express-interest/controllers/express-interest.js
+++ b/src/api/express-interest/controllers/express-interest.js
@@ -5,5 +5,29 @@
  */
 
 const { createCoreController } = require('@strapi/strapi').factories;
+const sendEmail = require('../../../utils/email');
 
-module.exports = createCoreController('api::express-interest.express-interest');
+module.exports = createCoreController('api::express-interest.express-interest', ({ strapi }) => ({
+  async create(ctx) {
+    // Step 1: Let Strapi create the entry
+    const response = await super.create(ctx);
+    const email = ctx.request.body.data?.email || '';
+    const firstName = ctx.request.body.data?.firstName || '';
+    // Step 2: Send email using SES
+    try {
+     console.log(email);
+      await sendEmail({
+        to: email,
+        subject: '',
+        templateName: 'express-interest',
+        replacements: { firstName },
+      });
+
+      strapi.log.info(`Confirmation email sent to ${email}`);
+    } catch (err) {
+      strapi.log.error('Failed to send email:', err);
+    }
+
+    return response;
+  }
+}));

--- a/src/api/newsletter/controllers/newsletter.js
+++ b/src/api/newsletter/controllers/newsletter.js
@@ -5,5 +5,28 @@
  */
 
 const { createCoreController } = require('@strapi/strapi').factories;
+const sendEmail = require('../../../utils/email');
 
-module.exports = createCoreController('api::newsletter.newsletter');
+module.exports = createCoreController('api::newsletter.newsletter', ({ strapi }) => ({
+  async create(ctx) {
+    // Step 1: Let Strapi create the entry
+    const response = await super.create(ctx);
+    const email = ctx.request.body.data?.email || '';
+    // Step 2: Send email using SES
+    try {
+     console.log(email);
+      await sendEmail({
+        to: email,
+        subject: '',
+        templateName: 'newsletter',
+        replacements: { email },
+      });
+
+      strapi.log.info(`Confirmation email sent to ${email}`);
+    } catch (err) {
+      strapi.log.error('Failed to send email:', err);
+    }
+
+    return response;
+  }
+}));

--- a/src/email-templates/express-interest.html
+++ b/src/email-templates/express-interest.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body style="height: 100vh; display: flex; align-items: center;">
+    <div style="max-width: 798px; margin: 0 auto;">
+        <table width="100%"
+            style="max-width: 798px; margin: 20px auto; background-color: #ffffff; border-radius: 12px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1); overflow: hidden; border-collapse: collapse; font-family: Arial, Helvetica, sans-serif;">
+            <thead>
+                <tr>
+                    <td>
+                        <img src="./assets/Global-fintech.jpg" alt="Logo" style="max-width: 100%;">
+                    </td>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td style="padding: 32px 10% 32px; text-align: left;">
+                        <p style="margin: 0 0 10px; font-size: 20px; font-weight: 600; line-height:100%">Hello, {{firstName}}
+                        </p>
+                        <p style="margin: 0 0 32px; font-size: 20px; font-weight: 400; line-height:140%">We have
+                            received your details for your interest in joining the team for the event. You’ll hear back
+                            from us very soon. Keep a check on your email inbox.</p>
+                        <h2
+                            style="margin: 0 0 32px; font-size: 32px; font-weight: 700; line-height:100%; color:#2208EB;">
+                            Thanks for Expressing Interest!</h2>
+                        <p style="font-size: 20px; font-weight: 400; line-height:100%">If you have any queries, feel
+                            free to reach us out at</p>
+                        <a href="#"
+                            style="text-decoration: underline; font-size: 20px; font-weight: 400; line-height:100%; color: #111;">info@globalfintechfest.com</a>
+                        <hr style="margin-top: 32px; color: #111; opacity: 20%;">
+                        <p style="margin: 32px 0 24px; font-size: 12px; color: #888888;">Disclaimer: This is an
+                            automated email. Please do not reply to this email as incoming emails are not monitored.</p>
+                        <p style="margin: 0; font-size: 12px; color: #888888;">If you don’t wish to be on the
+                            subscription list, <a href="#"
+                                style="text-decoration: underline; color: #111;">unsubscribe</a>.</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</body>
+
+</html>

--- a/src/email-templates/newsletter.html
+++ b/src/email-templates/newsletter.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Document</title>
+</head>
+
+<body style="height: 100vh; display: flex; align-items: center;">
+    <div style="max-width: 798px; margin: 0 auto;">
+        <table width="100%"
+            style="max-width: 798px; margin: 20px auto; background-color: #ffffff; border-radius: 12px; box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1); overflow: hidden; border-collapse: collapse; font-family: Arial, Helvetica, sans-serif;">
+            <thead>
+                <tr>
+                    <td>
+                        <img src="./assets/Global-fintech.jpg" alt="Logo" style="width: 100%;">
+                    </td>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td style="padding: 32px 10% 32px; text-align: left;">
+                        <p style="margin: 0 0 10px; font-size: 20px; font-weight: 600; line-height:100%">Hello, {{email}}
+                        </p>
+                        <p style="margin: 0 0 32px; font-size: 20px; font-weight: 400; line-height:140%">It’s good to
+                            have you.</p>
+                        <h2
+                            style="margin: 0 0 32px; font-size: 32px; font-weight: 700; line-height:100%; color:#2208EB;">
+                            Thanks for signing up!</h2>
+                        <hr style="margin-top: 32px; color: #111; opacity: 20%;">
+                        <p style="margin: 32px 0 24px; font-size: 12px; color: #888888;">Disclaimer: This is an
+                            automated email. Please do not reply to this email or incoming emails or replies are not
+                            monitored.</p>
+                        <p style="margin: 0; font-size: 12px; color: #888888;">If you don’t wish to be on the
+                            subscription list, Please <a href="#"
+                                style="text-decoration: underline; color: #111;">unsubscribe</a>.</p>
+                    </td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+</body>
+
+</html>

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-05-31T07:52:54.271Z"
+    "x-generation-date": "2025-06-02T07:04:11.311Z"
   },
   "x-strapi-config": {
     "plugins": [

--- a/src/utils/email.js
+++ b/src/utils/email.js
@@ -1,0 +1,30 @@
+const fs = require('fs');
+const path = require('path');
+const nodemailer = require('nodemailer');
+
+module.exports = async ({ to, subject, templateName, replacements }) => {
+  const templatePath = path.join(strapi.dirs.app.root, 'src', 'email-templates', `${templateName}.html`);
+  let html = fs.readFileSync(templatePath, 'utf8');
+
+  // Replace placeholders
+  for (const [key, value] of Object.entries(replacements)) {
+    html = html.replace(new RegExp(`{{${key}}}`, 'g'), value);
+  }
+
+  const transporter = nodemailer.createTransport({
+    host: process.env.SMTP_HOST,
+    port: parseInt(process.env.SMTP_PORT),
+    secure: false,
+    auth: {
+      user: process.env.AWS_SES_USER,
+      pass: process.env.AWS_SES_PASS,
+    },
+  });
+
+  await transporter.sendMail({
+    from: process.env.AWS_SES_EMAIL_FROM,
+    to,
+    subject,
+    html,
+  });
+};


### PR DESCRIPTION
- Updated the facilitator registration logic to first check if the user already exists in AWS Cognito.
- If the user exists and has `custom:delegate` set to true, registration is blocked with a clear error message.
- If the user exists and is not a delegate:
  - If the corresponding Strapi facilitator entry has `passBought` set to true, registration is blocked as completed.
  - If `passBought` is false or not found, both the Cognito user and facilitator entry are deleted, allowing fresh registration.
- Ensured `isCognitoVerified` is also checked before deciding on deletion.
- Added initial support for email templates under `src/email-templates`, with assets and sample image handling.
- Configured AWS SES integration and verified that email images from local assets are correctly rendered in outgoing emails.