### PR TITLE
Implement CRM integration in facilitator and delegate

### DIFF
--- a/src/api/delegate/content-types/delegate/schema.json
+++ b/src/api/delegate/content-types/delegate/schema.json
@@ -45,6 +45,12 @@
     },
     "confirmationId": {
       "type": "string"
+    },
+    "passType": {
+      "type": "string"
+    },
+    "passPrice": {
+      "type": "decimal"
     }
   }
 }

--- a/src/api/delegate/controllers/delegate.js
+++ b/src/api/delegate/controllers/delegate.js
@@ -7,15 +7,16 @@
 // @ts-ignore
 const {
   // @ts-ignore
-  CognitoIdentityProviderClient, AdminCreateUserCommand, AdminSetUserPasswordCommand,
+  CognitoIdentityProviderClient, AdminCreateUserCommand, AdminSetUserPasswordCommand, ListUsersCommand,
   // @ts-ignore
-  InitiateAuthCommand, RespondToAuthChallengeCommand, AdminUpdateUserAttributesCommand, AdminGetUserCommand 
+  InitiateAuthCommand, RespondToAuthChallengeCommand, AdminUpdateUserAttributesCommand, AdminGetUserCommand
 } = require('@aws-sdk/client-cognito-identity-provider');
 const facilitator = require('../../facilitator/controllers/facilitator');
 
 // @ts-ignore
 const { createCoreController } = require('@strapi/strapi').factories;
 const sendEmail = require('../../../utils/email');
+const { updateSalesforceParticipant } = require('../../../utils/salesforce');
 
 const client = new CognitoIdentityProviderClient({ region: process.env.AWS_REGION });
 
@@ -44,22 +45,72 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
 
   async create(ctx) {
     const { data } = ctx.request.body;
-  
+
     try {
-      // 1. Get country details
-      const country = await strapi.entityService.findOne('api::country.country', data.country, {
-        fields: ['country', 'countryCode'],
+      // 1. Extract passType from wcProductName (e.g. "Gold Pass 1" => "Gold")
+      const passType = data.wcProductName.split(' ')[0];
+
+      // 2. Find all delegates with same facilitatorId and passType
+      const delegates = await strapi.entityService.findMany('api::delegate.delegate', {
+        filters: {
+          facilitatorId: data.facilitatorId,
+          passType,
+        },
       });
-  
-      if (!country || !country.countryCode) {
-        return ctx.badRequest('Invalid or missing country');
+
+      // 3. Find first delegate with any empty required field
+      let delegateToUpdate = null;
+      console.log('Delegates found:', delegates.length);
+      for (const d of delegates) {
+        console.log({
+          id: d.id,
+          cognitoId: d.cognitoId,
+          wcProductId: d.wcProductId,
+          wcProductName: d.wcProductName,
+          isFacilitator: d.isFacilitator,
+          country: d.country,
+        });
       }
-  
-      const formattedPhone = `${country.countryCode}${data.mobileNumber}`;
-      let cognitoId;
-  
-      if (!data.isFacilitator) {
-        // 2. Register delegate in Cognito
+      for (const d of delegates) {
+        const hasMissingFields =
+          !d.cognitoId ||
+          !d.wcProductId ||
+          !d.wcProductName ||
+          typeof d.isFacilitator !== 'boolean';
+
+        if (hasMissingFields) {
+          delegateToUpdate = d;
+          break;
+        }
+      }
+
+      if (!delegateToUpdate) {
+        // If none empty, return error (FE should prevent this)
+        return ctx.conflict(`No available delegate slot for pass type: ${passType}`);
+      }
+
+      const updatedFields = {};
+
+      // 4. Fill fields only if empty
+      if (!delegateToUpdate.wcProductId) updatedFields.wcProductId = data.wcProductId;
+      if (!delegateToUpdate.wcProductName) updatedFields.wcProductName = data.wcProductName;
+      if (!delegateToUpdate.isFacilitator) updatedFields.isFacilitator = data.isFacilitator || false;
+      if (!delegateToUpdate.country) updatedFields.country = data.country;
+      if (!delegateToUpdate.sector) updatedFields.sector = data.sector || null;
+
+      // 5. Create Cognito user if not facilitator and cognitoId missing
+      let cognitoId = delegateToUpdate.cognitoId;
+      if (!data.isFacilitator && !cognitoId) {
+        const country = await strapi.entityService.findOne('api::country.country', data.country, {
+          fields: ['country', 'countryCode'],
+        });
+
+        if (!country || !country.countryCode) {
+          return ctx.badRequest('Invalid or missing country');
+        }
+
+        const formattedPhone = `${country.countryCode}${data.mobileNumber}`;
+
         try {
           const createCommand = new AdminCreateUserCommand({
             UserPoolId: process.env.COGNITO_USER_POOL_ID,
@@ -77,18 +128,18 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
               ...(data.companyName ? [{ Name: 'custom:companyName', Value: data.companyName }] : []),
             ],
           });
-  
+
           const response = await client.send(createCommand);
           cognitoId = response.User.Username;
-  
-          // 3. Set permanent password
+
+          // Set permanent password
           const passwordCommand = new AdminSetUserPasswordCommand({
             UserPoolId: process.env.COGNITO_USER_POOL_ID,
             Username: data.officialEmailAddress,
             Password: 'Temp@123',
             Permanent: true,
           });
-  
+
           await client.send(passwordCommand);
         } catch (error) {
           if (error.name === 'UsernameExistsException') {
@@ -96,68 +147,78 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
           }
           throw error;
         }
-  
-      } else {
-        // 4. Use Cognito ID of the primary account
-        const primary = await strapi.entityService.findOne('api::facilitator.facilitator', data.facilitatorId, {
-          fields: ['cognitoId'],
-        });
-  
-        if (!primary?.cognitoId) {
-          return ctx.badRequest('Invalid parent or missing Cognito ID');
-        }
-  
-        cognitoId = primary.cognitoId;
       }
-  
-      // 5. Create delegate entry
-      const delegateEntry = await strapi.entityService.create('api::delegate.delegate', {
-        data: {
-          facilitatorId: data.facilitatorId,
-          isFacilitator: data.isFacilitator || false,
-          wcProductId: data.wcProductId,
-          wcProductName: data.wcProductName,
-          cognitoId,
-          country: data.country,
-          sector: data.sector || null,
-        },
-      });
-  
-      // 6. Generate and update confirmationId
-      const confirmationId = `GFF25${String(delegateEntry.id).padStart(6, '0')}`;
-      await strapi.entityService.update('api::delegate.delegate', delegateEntry.id, {
-        data: { confirmationId },
-      });
-  
-      // 7. Fetch full delegate record with relations
-      const fullDelegate = await strapi.entityService.findOne('api::delegate.delegate', delegateEntry.id, {
+
+      updatedFields.cognitoId = cognitoId;
+
+      // 6. Update delegate entry
+      const updatedDelegate = await strapi.entityService.update(
+        'api::delegate.delegate',
+        delegateToUpdate.id,
+        {
+          data: updatedFields,
+        }
+      );
+
+      // 8. Fetch full delegate record with relations
+      const fullDelegate = await strapi.entityService.findOne('api::delegate.delegate', updatedDelegate.id, {
         populate: {
           country: { fields: ['country', 'countryCode'] },
           sector: { fields: ['name'] },
         },
       });
 
+      // 9. Send verification email
       const firstName = data.firstName;
       const email = data.officialEmailAddress;
-      const passType = data.wcProductName.split(' ')[0];
+      const passTypeForEmail = passType;
 
       await sendEmail({
-              to: email,
-              subject: 'Thank You for Registering to GFF 2025! ',
-              templateName: 'verification',
-              replacements: { passType, firstName, confirmationId },
-            });
-  
+        to: email,
+        subject: 'Thank You for Registering to GFF 2025!',
+        templateName: 'verification',
+        replacements: { passType: passTypeForEmail, firstName, confirmationId: fullDelegate.confirmationId },
+      });
+
+      const salesforcePayload = {
+        upgrade: 'false',
+        passType: passType,
+        price: fullDelegate.price,
+        confirmationId: fullDelegate.confirmationId,
+        email: data.officialEmailAddress,
+        mobilePhone: `${fullDelegate.country.countryCode}${data.mobileNumber}`,
+        participantFirstName: data.firstName,
+        participantLastName: data.lastName,
+        company: data.companyName || 'ABC',
+        sector: fullDelegate.sector.name || 'ABC', // you may need to fetch this from sector relation
+        vertical: 'Engineer',
+        level: 'Founder',
+        GenderIdentity: 'Male',
+        title: 'Engineer',
+        linkdinProfile: 'ABC',
+        twitterProfile: 'ABC',
+        instagramProfile: 'ABC',
+        personalEmail: data.officialEmailAddress
+      };
+
+      try {
+        await updateSalesforceParticipant(salesforcePayload);
+        strapi.log.info(`Salesforce updated for delegate ${fullDelegate.confirmationId}`);
+      } catch (error) {
+        strapi.log.error('Salesforce update failed:', error.message || error);
+      }
+
+      // 10. Return updated delegate with extra info
       return {
         ...fullDelegate,
-        confirmationId,
+        confirmationId: fullDelegate.confirmationId,
         firstName: data.firstName,
         lastName: data.lastName,
         officialEmailAddress: data.officialEmailAddress,
         mobileNumber: data.mobileNumber,
         companyName: data.companyName || null,
       };
-  
+
     } catch (error) {
       console.error('Delegate creation failed:', error);
       return ctx.internalServerError('Failed to create delegate');
@@ -167,17 +228,22 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
   async update(ctx) {
     const { id } = ctx.params;
     const { data } = ctx.request.body;
-  
+
     if (!id || typeof id !== 'string') {
       return ctx.badRequest('Invalid ID');
     }
-  
+
     try {
-      const existing = await strapi.entityService.findOne('api::delegate.delegate', id);
+      const existing = await strapi.entityService.findOne('api::delegate.delegate', id, {
+        populate: {
+          country: { fields: ['country', 'countryCode'] },
+          sector: { fields: ['name'] },
+        },
+      });
       if (!existing) {
         return ctx.notFound('Delegate not found');
       }
-  
+
       // Only update in Cognito
       if (existing.cognitoId) {
         const updateCommand = new AdminUpdateUserAttributesCommand({
@@ -188,12 +254,45 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
             { Name: 'custom:lastName', Value: data.lastName },
           ],
         });
-  
+
         await client.send(updateCommand);
       }
-  
+
+      const cognitoUser = await getCognitoUserBySub(existing.cognitoId);
+      const email = cognitoUser?.email || '';
+      const mobilePhone = cognitoUser?.phone_number || '';
+      const companyName = cognitoUser?.companyName || '';
+
+      const salesforcePayload = {
+        upgrade: 'true',
+        passType: existing.passType,
+        price: existing.price,
+        confirmationId: existing.confirmationId,
+        email: email,
+        mobilePhone: `${existing.country.countryCode}${mobilePhone}`,
+        participantFirstName: data.firstName,
+        participantLastName: data.lastName,
+        company: companyName || 'ABC',
+        sector: existing.sector.name || 'ABC', // you may need to fetch this from sector relation
+        vertical: 'Engineer',
+        level: 'Founder',
+        GenderIdentity: 'Male',
+        title: 'Engineer',
+        linkdinProfile: 'ABC',
+        twitterProfile: 'ABC',
+        instagramProfile: 'ABC',
+        personalEmail: data.officialEmailAddress
+      };
+
+      try {
+        await updateSalesforceParticipant(salesforcePayload);
+        strapi.log.info(`Salesforce updated for delegate ${existing.confirmationId}`);
+      } catch (error) {
+        strapi.log.error('Salesforce update failed:', error.message || error);
+      }
+
       return { message: 'Delegate name updated in Cognito successfully' };
-  
+
     } catch (error) {
       console.error('Update error:', error);
       return ctx.internalServerError('An error occurred while updating the delegate');
@@ -214,11 +313,11 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
 
   async login(ctx) {
     const { officialEmailAddress } = ctx.request.body;
-  
+
     if (!officialEmailAddress) {
       return ctx.badRequest('Missing email');
     }
-  
+
     try {
       // 1. Start Cognito Auth flow
       const command = new InitiateAuthCommand({
@@ -228,37 +327,37 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
           USERNAME: officialEmailAddress,
         },
       });
-  
+
       const response = await client.send(command);
-  
+
       // 2. Fetch the Cognito user to get their sub (ID)
       const getUserCommand = new AdminGetUserCommand({
         UserPoolId: process.env.COGNITO_USER_POOL_ID,
         Username: officialEmailAddress,
       });
-  
+
       const user = await client.send(getUserCommand);
       const cognitoId = user?.UserAttributes?.find(attr => attr.Name === 'sub')?.Value;
-  
+
       if (!cognitoId) {
         return ctx.notFound('User not found in Cognito');
       }
-  
+
       // 3. Check if delegate exists in Strapi using Cognito ID
       const delegate = await strapi.db.query('api::delegate.delegate').findOne({
         where: { cognitoId },
       });
-  
+
       if (!delegate) {
         return ctx.notFound('Delegate not found');
       }
-  
+
       // 4. Return session for OTP challenge
       return ctx.send({
         message: 'OTP sent to email',
         session: response.Session,
       });
-  
+
     } catch (error) {
       console.error('Login error:', error);
       return ctx.internalServerError('Failed to process login');
@@ -267,11 +366,11 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
 
   async verifyLoginOtp(ctx) {
     const { officialEmailAddress, otp, session } = ctx.request.body;
-  
+
     if (!officialEmailAddress || !otp || !session) {
       return ctx.badRequest('Missing data');
     }
-  
+
     try {
       const command = new RespondToAuthChallengeCommand({
         ClientId: process.env.COGNITO_CLIENT_ID,
@@ -282,35 +381,35 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
           ANSWER: otp,
         },
       });
-  
+
       const response = await client.send(command);
-  
+
       if (!response.AuthenticationResult) {
         return ctx.unauthorized('Authentication failed');
       }
-  
+
       // Get user info from Cognito
       const getUserCommand = new AdminGetUserCommand({
         UserPoolId: process.env.COGNITO_USER_POOL_ID,
         Username: officialEmailAddress,
       });
-  
+
       const user = await client.send(getUserCommand);
       const attributes = user.UserAttributes;
-  
+
       const getAttr = (name) => attributes.find((attr) => attr.Name === name)?.Value;
-  
+
       const cognitoId = getAttr('sub');
       const email = getAttr('email');
       const phone = getAttr('phone_number');
       const firstName = getAttr('custom:firstName');
       const lastName = getAttr('custom:lastName');
       const companyName = getAttr('custom:companyName') || null;
-  
+
       if (!cognitoId) {
         return ctx.notFound('Cognito user ID not found');
       }
-  
+
       // Find delegate in Strapi using Cognito ID
       const delegate = await strapi.db.query('api::delegate.delegate').findOne({
         where: { cognitoId },
@@ -319,17 +418,17 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
           country: true,
         },
       });
-  
+
       if (!delegate) {
         return ctx.notFound('Delegate not found');
       }
-  
+
       // Strip country code from mobile number
       const countryCode = delegate.country?.countryCode || '';
       const mobileNumber = phone?.startsWith(countryCode)
         ? phone.slice(countryCode.length)
         : phone;
-  
+
       return ctx.send({
         message: 'Login successful',
         idToken: response.AuthenticationResult?.IdToken,
@@ -345,7 +444,7 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
           ...delegate,
         },
       });
-  
+
     } catch (error) {
       console.error('OTP verification failed:', error);
       return ctx.internalServerError('An unexpected error occurred');
@@ -353,3 +452,37 @@ module.exports = createCoreController('api::delegate.delegate', ({ strapi }) => 
   },
 
 }));
+
+async function getCognitoUserBySub(sub) {
+  if (!sub) return null;
+
+  try {
+    const listUsersCommand = new ListUsersCommand({
+      UserPoolId: process.env.COGNITO_USER_POOL_ID,
+      Filter: `sub = "${sub}"`,
+      Limit: 1,
+    });
+
+    const response = await client.send(listUsersCommand);
+
+    if (!response.Users || response.Users.length === 0) return null;
+
+    const user = response.Users[0];
+    const attributes = {};
+    for (const attr of user.Attributes) {
+      attributes[attr.Name] = attr.Value;
+    }
+
+    return {
+      sub: attributes.sub,
+      email: attributes.email,
+      phone_number: attributes.phone_number,
+      firstName: attributes['custom:firstName'] || '',
+      lastName: attributes['custom:lastName'] || '',
+      companyName: attributes['custom:companyName'] || '',
+    };
+  } catch (err) {
+    console.error('Failed to fetch Cognito user:', err);
+    return null;
+  }
+}

--- a/src/api/early-stage-pitch/content-types/early-stage-pitch/schema.json
+++ b/src/api/early-stage-pitch/content-types/early-stage-pitch/schema.json
@@ -11,9 +11,6 @@
     "draftAndPublish": false
   },
   "attributes": {
-    "fullName": {
-      "type": "string"
-    },
     "firstName": {
       "type": "string"
     },

--- a/src/api/express-interest/content-types/express-interest/schema.json
+++ b/src/api/express-interest/content-types/express-interest/schema.json
@@ -11,9 +11,6 @@
     "draftAndPublish": false
   },
   "attributes": {
-    "fullName": {
-      "type": "string"
-    },
     "firstName": {
       "type": "string"
     },

--- a/src/components/common/woo-order-details.json
+++ b/src/components/common/woo-order-details.json
@@ -1,7 +1,8 @@
 {
   "collectionName": "components_common_woo_order_details",
   "info": {
-    "displayName": "WooOrderDetails"
+    "displayName": "WooOrderDetails",
+    "description": ""
   },
   "options": {},
   "attributes": {
@@ -17,6 +18,9 @@
     "isActive": {
       "type": "boolean",
       "default": true
+    },
+    "crmRegistrationPaymentId": {
+      "type": "string"
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-05T08:16:42.285Z"
+    "x-generation-date": "2025-06-06T11:58:22.870Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -9099,6 +9099,13 @@
               "confirmationId": {
                 "type": "string"
               },
+              "passType": {
+                "type": "string"
+              },
+              "passPrice": {
+                "type": "number",
+                "format": "float"
+              },
               "locale": {
                 "type": "string"
               },
@@ -9683,6 +9690,13 @@
                     "confirmationId": {
                       "type": "string"
                     },
+                    "passType": {
+                      "type": "string"
+                    },
+                    "passPrice": {
+                      "type": "number",
+                      "format": "float"
+                    },
                     "createdAt": {
                       "type": "string",
                       "format": "date-time"
@@ -9816,6 +9830,13 @@
           "confirmationId": {
             "type": "string"
           },
+          "passType": {
+            "type": "string"
+          },
+          "passPrice": {
+            "type": "number",
+            "format": "float"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -9924,6 +9945,9 @@
           },
           "isActive": {
             "type": "boolean"
+          },
+          "crmRegistrationPaymentId": {
+            "type": "string"
           }
         }
       },
@@ -9936,9 +9960,6 @@
           "data": {
             "type": "object",
             "properties": {
-              "fullName": {
-                "type": "string"
-              },
               "firstName": {
                 "type": "string"
               },
@@ -10033,9 +10054,6 @@
             "type": "number"
           },
           "documentId": {
-            "type": "string"
-          },
-          "fullName": {
             "type": "string"
           },
           "firstName": {
@@ -10369,9 +10387,6 @@
                 "documentId": {
                   "type": "string"
                 },
-                "fullName": {
-                  "type": "string"
-                },
                 "firstName": {
                   "type": "string"
                 },
@@ -10479,9 +10494,6 @@
           "data": {
             "type": "object",
             "properties": {
-              "fullName": {
-                "type": "string"
-              },
               "firstName": {
                 "type": "string"
               },
@@ -10588,9 +10600,6 @@
             "type": "number"
           },
           "documentId": {
-            "type": "string"
-          },
-          "fullName": {
             "type": "string"
           },
           "firstName": {
@@ -10934,9 +10943,6 @@
                   "type": "number"
                 },
                 "documentId": {
-                  "type": "string"
-                },
-                "fullName": {
                   "type": "string"
                 },
                 "firstName": {
@@ -11806,6 +11812,13 @@
                 },
                 "confirmationId": {
                   "type": "string"
+                },
+                "passType": {
+                  "type": "string"
+                },
+                "passPrice": {
+                  "type": "number",
+                  "format": "float"
                 },
                 "createdAt": {
                   "type": "string",

--- a/src/utils/salesforce.js
+++ b/src/utils/salesforce.js
@@ -1,0 +1,159 @@
+let salesforceToken = null;
+const insertEndpoint = `${process.env.CRM_BASE_URL}/apexrest/RegistrationParticipant/`;
+const updateEndpoint = `${process.env.CRM_BASE_URL}/apexrest/UpdateBulkRegistrationParticipant/`;
+
+async function getSalesforceToken() {
+  try {
+    const res = await fetch(`${process.env.CRM_BASE_URL}/oauth2/token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: new URLSearchParams({
+        grant_type: process.env.CRM_GRANT_TYPE,
+        client_id: process.env.CRM_CLIENT_ID,
+        client_secret: process.env.CRM_CLIENT_SECRET,
+      }),
+    });
+
+    const data = await res.json();
+
+    if (!res.ok || !data.access_token) {
+      throw new Error(data.error_description || 'Salesforce token fetch failed');
+    }
+
+    salesforceToken = data.access_token;
+    return salesforceToken;
+  } catch (err) {
+    console.error('Salesforce Auth Error:', err.message);
+    throw err;
+  }
+}
+
+async function insertIntoSalesforce(payload) {
+  if (!salesforceToken) {
+    await getSalesforceToken();
+  }
+
+  const doInsert = async () => {
+  const res = await fetch(insertEndpoint, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${salesforceToken}`,
+      'Content-Type': 'text/plain',
+    },
+    body: JSON.stringify(payload),
+  });
+
+  const text = await res.text();
+  let parsed;
+
+  try {
+    parsed = JSON.parse(text);
+  } catch (e) {
+    parsed = text;
+  }
+
+  const bodyText = typeof parsed === 'string' ? parsed : JSON.stringify(parsed);
+  const isTokenExpired =
+    res.status === 401 ||
+    res.status === 403 ||
+    bodyText.includes('INVALID_SESSION_ID') ||
+    bodyText.toLowerCase().includes('session') && bodyText.toLowerCase().includes('expired');
+
+  if (isTokenExpired) {
+    return { retry: true };
+  }
+
+  if (!res.ok) {
+    console.error('Salesforce Insert Error:', parsed);
+    throw new Error('Salesforce insert failed');
+  }
+  console.log('parsed = ',parsed);
+  
+
+  return { retry: false, data: parsed };
+};
+
+  // First try
+  let result = await doInsert();
+
+  // Retry once if session expired
+  if (result.retry) {
+    console.warn('Salesforce session expired, retrying after token refresh...');
+    await getSalesforceToken();
+    result = await doInsert();
+
+    if (result.retry) {
+      throw new Error('Salesforce insert failed after token refresh');
+    }
+  }
+
+  return result.data;
+}
+
+async function updateSalesforceParticipant(delegatePayload) {
+  if (!salesforceToken) {
+    await getSalesforceToken();
+  }
+
+  const doUpdate = async () => {
+    const res = await fetch(updateEndpoint, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${salesforceToken}`,
+        'Content-Type': 'text/plain',
+      },
+      body: JSON.stringify([delegatePayload]), // Wrap single payload in array
+    });
+
+    const text = await res.text();
+    let parsed;
+
+    try {
+      parsed = JSON.parse(text);
+    } catch (e) {
+      parsed = text;
+    }
+
+    const bodyText = typeof parsed === 'string' ? parsed : JSON.stringify(parsed);
+    const isTokenExpired =
+      res.status === 401 ||
+      res.status === 403 ||
+      bodyText.includes('INVALID_SESSION_ID') ||
+      (bodyText.toLowerCase().includes('session') && bodyText.toLowerCase().includes('expired'));
+
+    if (isTokenExpired) {
+      return { retry: true };
+    }
+
+    if (!res.ok) {
+      console.error('Salesforce Update Error:', parsed);
+      throw new Error('Salesforce update failed');
+    }
+
+    return { retry: false, data: parsed };
+  };
+
+  // First try
+  let result = await doUpdate();
+
+  // Retry once if session expired
+  if (result.retry) {
+    console.warn('Salesforce session expired (update), retrying after token refresh...');
+    await getSalesforceToken();
+    result = await doUpdate();
+
+    if (result.retry) {
+      throw new Error('Salesforce update failed after token refresh');
+    }
+  }
+
+  return result.data;
+}
+
+module.exports = {
+  insertIntoSalesforce,
+  getSalesforceToken, // optional if you also want to use it elsewhere
+  updateSalesforceParticipant,
+};

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -18,9 +18,11 @@ export interface CommonGstDetails extends Struct.ComponentSchema {
 export interface CommonWooOrderDetails extends Struct.ComponentSchema {
   collectionName: 'components_common_woo_order_details';
   info: {
+    description: '';
     displayName: 'WooOrderDetails';
   };
   attributes: {
+    crmRegistrationPaymentId: Schema.Attribute.String;
     isActive: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<true>;
     totalAmount: Schema.Attribute.Decimal;
     wcOrderId: Schema.Attribute.String;

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -504,6 +504,8 @@ export interface ApiDelegateDelegate extends Struct.CollectionTypeSchema {
       'api::delegate.delegate'
     > &
       Schema.Attribute.Private;
+    passPrice: Schema.Attribute.Decimal;
+    passType: Schema.Attribute.String;
     publishedAt: Schema.Attribute.DateTime;
     sector: Schema.Attribute.Relation<'oneToOne', 'api::sector.sector'>;
     updatedAt: Schema.Attribute.DateTime;
@@ -536,7 +538,6 @@ export interface ApiEarlyStagePitchEarlyStagePitch
       Schema.Attribute.Private;
     emailAddress: Schema.Attribute.Email & Schema.Attribute.Unique;
     firstName: Schema.Attribute.String;
-    fullName: Schema.Attribute.String;
     isActive: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<true>;
     lastName: Schema.Attribute.String;
     linkedinUrl: Schema.Attribute.String;
@@ -576,7 +577,6 @@ export interface ApiExpressInterestExpressInterest
     designation: Schema.Attribute.String;
     email: Schema.Attribute.Email & Schema.Attribute.Unique;
     firstName: Schema.Attribute.String;
-    fullName: Schema.Attribute.String;
     isActive: Schema.Attribute.Boolean & Schema.Attribute.DefaultTo<true>;
     IsDelegate: Schema.Attribute.Boolean;
     IsPartnerOrExhibitor: Schema.Attribute.Boolean;


### PR DESCRIPTION
- Added full CRM (Salesforce) integration in the facilitator and delegate.
- Generates payload from WooCommerce order and Cognito details, sends to CRM API, and handles session retry logic. -Stores registrationPaymentId from CRM response into the correct WooOrder entry. 
- -Also supports multiple WooOrders and adds conditional logic for participant inclusion.