### PR TITLE
Update partner schema and documentation

### DIFF
--- a/src/api/partner/content-types/partner/schema.json
+++ b/src/api/partner/content-types/partner/schema.json
@@ -65,7 +65,9 @@
         "Spend Management Partner",
         "Silver Partners",
         "Mobile App Security Partner",
-        "Bronze Partners"
+        "Bronze Partners",
+        "By-Invite Diamond Partners",
+        "VIP Lounge Partner"
       ]
     },
     "partnerID": {

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-20T15:33:55.781Z"
+    "x-generation-date": "2025-06-20T16:28:02.939Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -23067,7 +23067,9 @@
                   "Spend Management Partner",
                   "Silver Partners",
                   "Mobile App Security Partner",
-                  "Bronze Partners"
+                  "Bronze Partners",
+                  "By-Invite Diamond Partners",
+                  "VIP Lounge Partner"
                 ]
               },
               "partnerID": {
@@ -23789,7 +23791,9 @@
               "Spend Management Partner",
               "Silver Partners",
               "Mobile App Security Partner",
-              "Bronze Partners"
+              "Bronze Partners",
+              "By-Invite Diamond Partners",
+              "VIP Lounge Partner"
             ]
           },
           "partnerID": {
@@ -24020,7 +24024,9 @@
                     "Spend Management Partner",
                     "Silver Partners",
                     "Mobile App Security Partner",
-                    "Bronze Partners"
+                    "Bronze Partners",
+                    "By-Invite Diamond Partners",
+                    "VIP Lounge Partner"
                   ]
                 },
                 "partnerID": {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -939,6 +939,8 @@ export interface ApiPartnerPartner extends Struct.CollectionTypeSchema {
         'Silver Partners',
         'Mobile App Security Partner',
         'Bronze Partners',
+        'By-Invite Diamond Partners',
+        'VIP Lounge Partner',
       ]
     >;
     partnerType: Schema.Attribute.Enumeration<


### PR DESCRIPTION
- Added new partner types: 'By-Invite Diamond Partners' and 'VIP Lounge Partner' in schema.json and contentTypes.d.ts.
- Updated partner types in full_documentation.json to reflect the new additions.
- Adjusted generation date in full_documentation.json.