### PR TITLE
Update speaker schema and documentation

### DIFF
--- a/src/api/speaker/content-types/speaker/schema.json
+++ b/src/api/speaker/content-types/speaker/schema.json
@@ -10,6 +10,7 @@
   "options": {
     "draftAndPublish": false
   },
+  "pluginOptions": {},
   "attributes": {
     "salutation": {
       "type": "enumeration",
@@ -69,6 +70,15 @@
     },
     "speakerPriorityinHomePage": {
       "type": "decimal"
+    },
+    "speakerType": {
+      "type": "enumeration",
+      "required": true,
+      "enum": [
+        "Tier 1",
+        "Category A",
+        "Category B"
+      ]
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-20T16:28:02.939Z"
+    "x-generation-date": "2025-06-23T05:19:10.326Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -29020,6 +29020,9 @@
         ],
         "properties": {
           "data": {
+            "required": [
+              "speakerType"
+            ],
             "type": "object",
             "properties": {
               "salutation": {
@@ -29088,6 +29091,14 @@
                 "type": "number",
                 "format": "float"
               },
+              "speakerType": {
+                "type": "string",
+                "enum": [
+                  "Tier 1",
+                  "Category A",
+                  "Category B"
+                ]
+              },
               "locale": {
                 "type": "string"
               },
@@ -29146,6 +29157,9 @@
       },
       "Speaker": {
         "type": "object",
+        "required": [
+          "speakerType"
+        ],
         "properties": {
           "id": {
             "type": "number"
@@ -29872,6 +29886,14 @@
             "type": "number",
             "format": "float"
           },
+          "speakerType": {
+            "type": "string",
+            "enum": [
+              "Tier 1",
+              "Category A",
+              "Category B"
+            ]
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -30103,6 +30125,14 @@
                 "speakerPriorityinHomePage": {
                   "type": "number",
                   "format": "float"
+                },
+                "speakerType": {
+                  "type": "string",
+                  "enum": [
+                    "Tier 1",
+                    "Category A",
+                    "Category B"
+                  ]
                 },
                 "createdAt": {
                   "type": "string",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -34,6 +34,10 @@ export interface AdminApiToken extends Struct.CollectionTypeSchema {
         minLength: 1;
       }> &
       Schema.Attribute.DefaultTo<''>;
+    encryptedKey: Schema.Attribute.Text &
+      Schema.Attribute.SetMinMaxLength<{
+        minLength: 1;
+      }>;
     expiresAt: Schema.Attribute.DateTime;
     lastUsedAt: Schema.Attribute.DateTime;
     lifespan: Schema.Attribute.BigInteger;
@@ -1271,6 +1275,10 @@ export interface ApiSpeakerSpeaker extends Struct.CollectionTypeSchema {
     speakerId: Schema.Attribute.UID;
     speakerPriorityinHomePage: Schema.Attribute.Decimal;
     speakerPriorityinSpeakerPage: Schema.Attribute.Decimal;
+    speakerType: Schema.Attribute.Enumeration<
+      ['Tier 1', 'Category A', 'Category B']
+    > &
+      Schema.Attribute.Required;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;


### PR DESCRIPTION
- Added new attribute 'speakerType' with enumeration values: 'Tier 1', 'Category A', and 'Category B' in schema.json and contentTypes.d.ts.
- Marked 'speakerType' as required in relevant sections of full_documentation.json.
- Updated generation date in full_documentation.json.