### PR TITLE
Add "By-Invite Dinner Partners" to partner schema and documentation

### DIFF
--- a/src/api/partner/content-types/partner/schema.json
+++ b/src/api/partner/content-types/partner/schema.json
@@ -67,6 +67,7 @@
         "Mobile App Security Partner",
         "Bronze Partners",
         "By-Invite Diamond Partners",
+        "By-Invite Dinner Partners",
         "VIP Lounge Partner"
       ]
     },

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-25T07:26:43.717Z"
+    "x-generation-date": "2025-06-25T11:06:18.596Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -23756,6 +23756,7 @@
                   "Mobile App Security Partner",
                   "Bronze Partners",
                   "By-Invite Diamond Partners",
+                  "By-Invite Dinner Partners",
                   "VIP Lounge Partner"
                 ]
               },
@@ -24480,6 +24481,7 @@
               "Mobile App Security Partner",
               "Bronze Partners",
               "By-Invite Diamond Partners",
+              "By-Invite Dinner Partners",
               "VIP Lounge Partner"
             ]
           },
@@ -24713,6 +24715,7 @@
                     "Mobile App Security Partner",
                     "Bronze Partners",
                     "By-Invite Diamond Partners",
+                    "By-Invite Dinner Partners",
                     "VIP Lounge Partner"
                   ]
                 },

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1005,6 +1005,7 @@ export interface ApiPartnerPartner extends Struct.CollectionTypeSchema {
         'Mobile App Security Partner',
         'Bronze Partners',
         'By-Invite Diamond Partners',
+        'By-Invite Dinner Partners',
         'VIP Lounge Partner',
       ]
     >;


### PR DESCRIPTION
- Updated partner schema to include "By-Invite Dinner Partners" in the list of partner types.
- Modified full documentation to reflect the new partner type across relevant sections.
- Ensured type definitions are consistent with the updated schema.