### PR TITLE
Add partnerfeatureinHomePage field to partner schema and documentation

### DIFF
--- a/src/api/partner/content-types/partner/schema.json
+++ b/src/api/partner/content-types/partner/schema.json
@@ -79,6 +79,10 @@
     },
     "partnerLogoAltText": {
       "type": "string"
+    },
+    "partnerfeatureinHomePage": {
+      "type": "boolean",
+      "default": false
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-26T09:16:59.871Z"
+    "x-generation-date": "2025-06-26T17:01:52.121Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -23807,6 +23807,9 @@
               "partnerLogoAltText": {
                 "type": "string"
               },
+              "partnerfeatureinHomePage": {
+                "type": "boolean"
+              },
               "locale": {
                 "type": "string"
               },
@@ -24531,6 +24534,9 @@
           "partnerLogoAltText": {
             "type": "string"
           },
+          "partnerfeatureinHomePage": {
+            "type": "boolean"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -24763,6 +24769,9 @@
                 },
                 "partnerLogoAltText": {
                   "type": "string"
+                },
+                "partnerfeatureinHomePage": {
+                  "type": "boolean"
                 },
                 "createdAt": {
                   "type": "string",

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -977,6 +977,8 @@ export interface ApiPartnerPartner extends Struct.CollectionTypeSchema {
       'api::partner.partner'
     > &
       Schema.Attribute.Private;
+    partnerfeatureinHomePage: Schema.Attribute.Boolean &
+      Schema.Attribute.DefaultTo<false>;
     partnerID: Schema.Attribute.UID<'partnerName'>;
     partnerLogo: Schema.Attribute.Media<
       'images' | 'files' | 'videos' | 'audios'


### PR DESCRIPTION
- Introduced partnerfeatureinHomePage as a boolean field with a default value of false in the partner schema.
- Updated full documentation and type definitions to include the new field.