### PR TITLE
Add session-related fields to agenda schema and documentation

### DIFF
--- a/src/api/agenda/content-types/agenda/schema.json
+++ b/src/api/agenda/content-types/agenda/schema.json
@@ -40,6 +40,15 @@
     },
     "session_format": {
       "type": "string"
+    },
+    "session_tags": {
+      "type": "string"
+    },
+    "session_host": {
+      "type": "string"
+    },
+    "session_speakers": {
+      "type": "string"
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-26T17:01:52.121Z"
+    "x-generation-date": "2025-06-27T04:25:25.583Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -13586,6 +13586,15 @@
               "session_format": {
                 "type": "string"
               },
+              "session_tags": {
+                "type": "string"
+              },
+              "session_host": {
+                "type": "string"
+              },
+              "session_speakers": {
+                "type": "string"
+              },
               "locale": {
                 "type": "string"
               },
@@ -13677,6 +13686,15 @@
             "type": "string"
           },
           "session_format": {
+            "type": "string"
+          },
+          "session_tags": {
+            "type": "string"
+          },
+          "session_host": {
+            "type": "string"
+          },
+          "session_speakers": {
             "type": "string"
           },
           "createdAt": {
@@ -14005,6 +14023,15 @@
                   "type": "string"
                 },
                 "session_format": {
+                  "type": "string"
+                },
+                "session_tags": {
+                  "type": "string"
+                },
+                "session_host": {
+                  "type": "string"
+                },
+                "session_speakers": {
                   "type": "string"
                 },
                 "createdAt": {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -398,9 +398,12 @@ export interface ApiAgendaAgenda extends Struct.CollectionTypeSchema {
     session_end_time: Schema.Attribute.String;
     session_format: Schema.Attribute.String;
     session_hall: Schema.Attribute.String;
+    session_host: Schema.Attribute.String;
     session_name: Schema.Attribute.String;
+    session_speakers: Schema.Attribute.String;
     session_start_time: Schema.Attribute.String;
     session_sub_hall: Schema.Attribute.String;
+    session_tags: Schema.Attribute.String;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;


### PR DESCRIPTION
- Introduced session_tags, session_host, and session_speakers as string fields in the agenda schema.
- Updated full documentation and type definitions to include the new session fields.