### PR TITLE
Update session_desc field type in agenda schema and documentation

### DIFF
--- a/src/api/agenda/content-types/agenda/schema.json
+++ b/src/api/agenda/content-types/agenda/schema.json
@@ -29,9 +29,6 @@
     "session_name": {
       "type": "string"
     },
-    "session_desc": {
-      "type": "blocks"
-    },
     "session_hall": {
       "type": "string"
     },
@@ -49,6 +46,9 @@
     },
     "session_speakers": {
       "type": "string"
+    },
+    "session_desc": {
+      "type": "text"
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-06-27T04:25:25.583Z"
+    "x-generation-date": "2025-06-27T05:15:57.837Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -13576,7 +13576,6 @@
               "session_name": {
                 "type": "string"
               },
-              "session_desc": {},
               "session_hall": {
                 "type": "string"
               },
@@ -13593,6 +13592,9 @@
                 "type": "string"
               },
               "session_speakers": {
+                "type": "string"
+              },
+              "session_desc": {
                 "type": "string"
               },
               "locale": {
@@ -13678,7 +13680,6 @@
           "session_name": {
             "type": "string"
           },
-          "session_desc": {},
           "session_hall": {
             "type": "string"
           },
@@ -13695,6 +13696,9 @@
             "type": "string"
           },
           "session_speakers": {
+            "type": "string"
+          },
+          "session_desc": {
             "type": "string"
           },
           "createdAt": {
@@ -14015,7 +14019,6 @@
                 "session_name": {
                   "type": "string"
                 },
-                "session_desc": {},
                 "session_hall": {
                   "type": "string"
                 },
@@ -14032,6 +14035,9 @@
                   "type": "string"
                 },
                 "session_speakers": {
+                  "type": "string"
+                },
+                "session_desc": {
                   "type": "string"
                 },
                 "createdAt": {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -394,7 +394,7 @@ export interface ApiAgendaAgenda extends Struct.CollectionTypeSchema {
       Schema.Attribute.Private;
     publishedAt: Schema.Attribute.DateTime;
     session_date: Schema.Attribute.String;
-    session_desc: Schema.Attribute.Blocks;
+    session_desc: Schema.Attribute.Text;
     session_end_time: Schema.Attribute.String;
     session_format: Schema.Attribute.String;
     session_hall: Schema.Attribute.String;


### PR DESCRIPTION
- Changed session_desc from blocks to text in the agenda schema.
- Updated full documentation and type definitions to reflect the new session_desc type.