### PR TITLE
Update API documentation and type definitions for new components

### DIFF
--- a/src/components/common-components/tracks-section.json
+++ b/src/components/common-components/tracks-section.json
@@ -1,0 +1,17 @@
+{
+  "collectionName": "components_common_components_tracks_sections",
+  "info": {
+    "displayName": "Tracks Section"
+  },
+  "options": {},
+  "attributes": {
+    "Title": {
+      "type": "string"
+    },
+    "eachTrackItem": {
+      "type": "component",
+      "repeatable": true,
+      "component": "repeatable-componnets.track-item-icon-title-desc"
+    }
+  }
+}

--- a/src/components/repeatable-componnets/track-item-icon-title-desc.json
+++ b/src/components/repeatable-componnets/track-item-icon-title-desc.json
@@ -1,0 +1,25 @@
+{
+  "collectionName": "components_repeatable_componnets_track_item_icon_title_descs",
+  "info": {
+    "displayName": "TrackItem_IconTitleDesc"
+  },
+  "options": {},
+  "attributes": {
+    "Icon": {
+      "allowedTypes": [
+        "images",
+        "files",
+        "videos",
+        "audios"
+      ],
+      "type": "media",
+      "multiple": false
+    },
+    "Title": {
+      "type": "string"
+    },
+    "Description": {
+      "type": "text"
+    }
+  }
+}

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-07-02T20:28:26.585Z"
+    "x-generation-date": "2025-07-02T20:53:46.975Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -18920,6 +18920,9 @@
           },
           "companyAddress": {
             "type": "string"
+          },
+          "isCompanyAddressSameAsBilling": {
+            "type": "boolean"
           }
         }
       },

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -29,9 +29,24 @@ export interface CommonComponentsRegText extends Struct.ComponentSchema {
   };
 }
 
+export interface CommonComponentsTracksSection extends Struct.ComponentSchema {
+  collectionName: 'components_common_components_tracks_sections';
+  info: {
+    displayName: 'Tracks Section';
+  };
+  attributes: {
+    eachTrackItem: Schema.Attribute.Component<
+      'repeatable-componnets.track-item-icon-title-desc',
+      true
+    >;
+    Title: Schema.Attribute.String;
+  };
+}
+
 export interface CommonGstDetails extends Struct.ComponentSchema {
   collectionName: 'components_common_gst_details';
   info: {
+    description: '';
     displayName: 'GstDetails';
   };
   attributes: {
@@ -40,6 +55,7 @@ export interface CommonGstDetails extends Struct.ComponentSchema {
     companyGstNo: Schema.Attribute.String;
     companyName: Schema.Attribute.String;
     companyPOC: Schema.Attribute.String;
+    isCompanyAddressSameAsBilling: Schema.Attribute.Boolean;
     pincode: Schema.Attribute.String;
   };
 }
@@ -103,16 +119,31 @@ export interface CommonWooOrderDetails extends Struct.ComponentSchema {
   };
 }
 
+export interface RepeatableComponnetsTrackItemIconTitleDesc
+  extends Struct.ComponentSchema {
+  collectionName: 'components_repeatable_componnets_track_item_icon_title_descs';
+  info: {
+    displayName: 'TrackItem_IconTitleDesc';
+  };
+  attributes: {
+    Description: Schema.Attribute.Text;
+    Icon: Schema.Attribute.Media<'images' | 'files' | 'videos' | 'audios'>;
+    Title: Schema.Attribute.String;
+  };
+}
+
 declare module '@strapi/strapi' {
   export module Public {
     export interface ComponentSchemas {
       'common-components.hero-section': CommonComponentsHeroSection;
       'common-components.reg-text': CommonComponentsRegText;
+      'common-components.tracks-section': CommonComponentsTracksSection;
       'common.gst-details': CommonGstDetails;
       'common.logo': CommonLogo;
       'common.logo-section': CommonLogoSection;
       'common.partner-show-in-page': CommonPartnerShowInPage;
       'common.woo-order-details': CommonWooOrderDetails;
+      'repeatable-componnets.track-item-icon-title-desc': RepeatableComponnetsTrackItemIconTitleDesc;
     }
   }
 }


### PR DESCRIPTION
- Updated generation date in full documentation.
- Added new component schema for CommonComponentsTracksSection.
- Introduced new field 'isCompanyAddressSameAsBilling' in CommonGstDetails and updated type definitions accordingly.
- Added RepeatableComponnetsTrackItemIconTitleDesc component schema.