### PR TITLE
Enhance Hero Section schema and documentation

### DIFF
--- a/src/components/common-components/hero-section.json
+++ b/src/components/common-components/hero-section.json
@@ -2,35 +2,44 @@
   "collectionName": "components_common_components_hero_sections",
   "info": {
     "displayName": "Hero Section",
-    "icon": "apps"
+    "icon": "apps",
+    "description": ""
   },
   "options": {},
   "attributes": {
     "TabletDesktopHeroImage": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
       "allowedTypes": [
         "images",
         "files",
         "videos",
         "audios"
-      ],
-      "type": "media",
-      "multiple": false
+      ]
     },
     "MobileImage": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
       "allowedTypes": [
         "images",
         "files",
         "videos",
         "audios"
-      ],
-      "type": "media",
-      "multiple": false
+      ]
     },
     "HeroHeadline": {
       "type": "string"
     },
     "HeroText": {
       "type": "text"
+    },
+    "CTAText": {
+      "type": "string"
+    },
+    "CTALink": {
+      "type": "string"
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-07-02T23:52:03.358Z"
+    "x-generation-date": "2025-07-03T02:14:06.054Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -29955,6 +29955,12 @@
             "type": "string"
           },
           "HeroText": {
+            "type": "string"
+          },
+          "CTAText": {
+            "type": "string"
+          },
+          "CTALink": {
             "type": "string"
           }
         }

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -17,10 +17,13 @@ export interface CommonComponentsCmImageTitleTextCta
 export interface CommonComponentsHeroSection extends Struct.ComponentSchema {
   collectionName: 'components_common_components_hero_sections';
   info: {
+    description: '';
     displayName: 'Hero Section';
     icon: 'apps';
   };
   attributes: {
+    CTALink: Schema.Attribute.String;
+    CTAText: Schema.Attribute.String;
     HeroHeadline: Schema.Attribute.String;
     HeroText: Schema.Attribute.Text;
     MobileImage: Schema.Attribute.Media<


### PR DESCRIPTION
- Added 'CTAText' and 'CTALink' attributes to the Hero Section schema.
- Updated the full documentation with the new attributes.
- Adjusted type definitions in generated files to include the new fields.