### PR TITLE
Add new partner types to schema and update documentation

### DIFF
--- a/src/api/partner/content-types/partner/schema.json
+++ b/src/api/partner/content-types/partner/schema.json
@@ -68,7 +68,9 @@
         "Mobile App Security Partner",
         "Bronze Partners",
         "VIP Lounge Partner",
-        "Beer Booth Partner"
+        "Beer Booth Partner",
+        "Banking Transformation Partner",
+        "Financial Inclusion Partner"
       ]
     },
     "partnerID": {

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-07-08T10:39:28.581Z"
+    "x-generation-date": "2025-07-08T10:48:32.094Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -37913,7 +37913,9 @@
                   "Mobile App Security Partner",
                   "Bronze Partners",
                   "VIP Lounge Partner",
-                  "Beer Booth Partner"
+                  "Beer Booth Partner",
+                  "Banking Transformation Partner",
+                  "Financial Inclusion Partner"
                 ]
               },
               "partnerID": {
@@ -38641,7 +38643,9 @@
               "Mobile App Security Partner",
               "Bronze Partners",
               "VIP Lounge Partner",
-              "Beer Booth Partner"
+              "Beer Booth Partner",
+              "Banking Transformation Partner",
+              "Financial Inclusion Partner"
             ]
           },
           "partnerID": {
@@ -38878,7 +38882,9 @@
                     "Mobile App Security Partner",
                     "Bronze Partners",
                     "VIP Lounge Partner",
-                    "Beer Booth Partner"
+                    "Beer Booth Partner",
+                    "Banking Transformation Partner",
+                    "Financial Inclusion Partner"
                   ]
                 },
                 "partnerID": {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1323,6 +1323,8 @@ export interface ApiPartnerPartner extends Struct.CollectionTypeSchema {
         'Bronze Partners',
         'VIP Lounge Partner',
         'Beer Booth Partner',
+        'Banking Transformation Partner',
+        'Financial Inclusion Partner',
       ]
     >;
     partnerType: Schema.Attribute.Enumeration<


### PR DESCRIPTION
- Added "Banking Transformation Partner" and "Financial Inclusion Partner" to partner types in schema.json and full_documentation.json.
- Updated x-generation-date in full_documentation.json.