### PR TITLE
Add SEO and Open Graph components to regular page schema

### DIFF
--- a/config/plugins.js
+++ b/config/plugins.js
@@ -1,17 +1,20 @@
 module.exports = () => ({
   "strapi-csv-import-export": {
-          config: {
-            authorizedExports: [
-              "api::become-a-speaker.become-a-speaker",
-              "api::express-interest.express-interest",
-              "api::early-stage-pitch.early-stage-pitch",
-              "api::newsletter.newsletter",
-              "api::confirmed-speaker.confirmed-speaker",
-              "api::hotel-information-form.hotel-information-form"
-            ],
-            // authorizedImports: ["api::become-a-speaker.become-a-speaker"]
-  }
-},
+    config: {
+      authorizedExports: [
+        "api::become-a-speaker.become-a-speaker",
+        "api::express-interest.express-interest",
+        "api::early-stage-pitch.early-stage-pitch",
+        "api::newsletter.newsletter",
+        "api::confirmed-speaker.confirmed-speaker",
+        "api::hotel-information-form.hotel-information-form"
+      ],
+      // authorizedImports: ["api::become-a-speaker.become-a-speaker"]
+      seo: {
+        enabled: true,
+      },
+    }
+  },
   upload: {
     config: {
       providerOptions: {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@aws-sdk/client-cognito-identity-provider": "^3.799.0",
         "@strapi/plugin-cloud": "5.11.0",
         "@strapi/plugin-documentation": "^5.13.0",
+        "@strapi/plugin-seo": "^2.0.8",
         "@strapi/plugin-users-permissions": "5.11.0",
         "@strapi/strapi": "5.11.0",
         "axios": "^1.9.0",
@@ -5114,6 +5115,45 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
       "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="
     },
+    "node_modules/@strapi/design-system": {
+      "version": "2.0.0-rc.28",
+      "resolved": "https://registry.npmjs.org/@strapi/design-system/-/design-system-2.0.0-rc.28.tgz",
+      "integrity": "sha512-aY5zVIXIyQs8J9vQqnHcngebJeTZAangtdAQQujEAB3Nb12V4S/zh2ocsDf60a8VwIfXWJNHgsSbnyHwqAdVqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/lang-json": "6.0.1",
+        "@floating-ui/react-dom": "2.1.0",
+        "@internationalized/date": "3.5.4",
+        "@internationalized/number": "3.5.3",
+        "@radix-ui/react-accordion": "1.1.2",
+        "@radix-ui/react-alert-dialog": "1.0.5",
+        "@radix-ui/react-avatar": "1.0.4",
+        "@radix-ui/react-checkbox": "1.0.4",
+        "@radix-ui/react-dialog": "1.0.5",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-dropdown-menu": "2.0.6",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-popover": "1.0.7",
+        "@radix-ui/react-progress": "1.0.3",
+        "@radix-ui/react-radio-group": "1.1.3",
+        "@radix-ui/react-scroll-area": "1.0.5",
+        "@radix-ui/react-switch": "1.0.3",
+        "@radix-ui/react-tabs": "1.0.4",
+        "@radix-ui/react-tooltip": "1.0.7",
+        "@radix-ui/react-use-callback-ref": "1.0.1",
+        "@strapi/ui-primitives": "2.0.0-rc.28",
+        "@uiw/react-codemirror": "4.22.2",
+        "lodash": "4.17.21",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "@strapi/icons": "^2.0.0 || ^2.0.0-beta || ^2.0.0-alpha",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0",
+        "styled-components": "^6.0.0"
+      }
+    },
     "node_modules/@strapi/email": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/@strapi/email/-/email-5.11.0.tgz",
@@ -6943,6 +6983,171 @@
         }
       }
     },
+    "node_modules/@strapi/plugin-seo": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/@strapi/plugin-seo/-/plugin-seo-2.0.8.tgz",
+      "integrity": "sha512-k0/O6cx/O9wlYOcp0ZIM6ISiamYbalrm157GGpkQpVFOdle62rH7ftA+60ZKqOi55xnnSpyYTIBe7y5gGcOkwQ==",
+      "dependencies": {
+        "@strapi/design-system": "^2.0.0-rc.10",
+        "@strapi/icons": "^2.0.0-rc.10",
+        "date-fns": "^4.1.0",
+        "lodash": "^4.17.21",
+        "prettier": "^3.3.3",
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0",
+        "react-intl": "^6.6.8",
+        "react-router-dom": "^6.0.0",
+        "showdown": "^2.1.0",
+        "styled-components": "^6.0.0"
+      },
+      "peerDependencies": {
+        "@strapi/strapi": "^5.0.6"
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/@formatjs/ecma402-abstract": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/ecma402-abstract/-/ecma402-abstract-2.2.4.tgz",
+      "integrity": "sha512-lFyiQDVvSbQOpU+WFd//ILolGj4UgA/qXrKeZxdV14uKiAUiPAtX6XAn7WBCRi7Mx6I7EybM9E5yYn4BIpZWYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/fast-memoize": "2.2.3",
+        "@formatjs/intl-localematcher": "0.5.8",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/@formatjs/fast-memoize": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/@formatjs/fast-memoize/-/fast-memoize-2.2.3.tgz",
+      "integrity": "sha512-3jeJ+HyOfu8osl3GNSL4vVHUuWFXR03Iz9jjgI7RwjG6ysu/Ymdr0JRCPHfF5yGbTE6JCrd63EpvX1/WybYRbA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/@formatjs/icu-messageformat-parser": {
+      "version": "2.9.4",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-messageformat-parser/-/icu-messageformat-parser-2.9.4.tgz",
+      "integrity": "sha512-Tbvp5a9IWuxUcpWNIW6GlMQYEc4rwNHR259uUFoKWNN1jM9obf9Ul0e+7r7MvFOBNcN+13K7NuKCKqQiAn1QEg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/icu-skeleton-parser": "1.8.8",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/@formatjs/icu-skeleton-parser": {
+      "version": "1.8.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/icu-skeleton-parser/-/icu-skeleton-parser-1.8.8.tgz",
+      "integrity": "sha512-vHwK3piXwamFcx5YQdCdJxUQ1WdTl6ANclt5xba5zLGDv5Bsur7qz8AD7BevaKxITwpgDeU0u8My3AIibW9ywA==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/@formatjs/intl": {
+      "version": "2.10.15",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl/-/intl-2.10.15.tgz",
+      "integrity": "sha512-i6+xVqT+6KCz7nBfk4ybMXmbKO36tKvbMKtgFz9KV+8idYFyFbfwKooYk8kGjyA5+T5f1kEPQM5IDLXucTAQ9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/fast-memoize": "2.2.3",
+        "@formatjs/icu-messageformat-parser": "2.9.4",
+        "@formatjs/intl-displaynames": "6.8.5",
+        "@formatjs/intl-listformat": "7.7.5",
+        "intl-messageformat": "10.7.7",
+        "tslib": "2"
+      },
+      "peerDependencies": {
+        "typescript": "^4.7 || 5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/@formatjs/intl-displaynames": {
+      "version": "6.8.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-displaynames/-/intl-displaynames-6.8.5.tgz",
+      "integrity": "sha512-85b+GdAKCsleS6cqVxf/Aw/uBd+20EM0wDpgaxzHo3RIR3bxF4xCJqH/Grbzx8CXurTgDDZHPdPdwJC+May41w==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/intl-localematcher": "0.5.8",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/@formatjs/intl-listformat": {
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-listformat/-/intl-listformat-7.7.5.tgz",
+      "integrity": "sha512-Wzes10SMNeYgnxYiKsda4rnHP3Q3II4XT2tZyOgnH5fWuHDtIkceuWlRQNsvrI3uiwP4hLqp2XdQTCsfkhXulg==",
+      "license": "MIT",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/intl-localematcher": "0.5.8",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/@formatjs/intl-localematcher": {
+      "version": "0.5.8",
+      "resolved": "https://registry.npmjs.org/@formatjs/intl-localematcher/-/intl-localematcher-0.5.8.tgz",
+      "integrity": "sha512-I+WDNWWJFZie+jkfkiK5Mp4hEDyRSEvmyfYadflOno/mmKJKcB17fEpEH0oJu/OWhhCJ8kJBDz2YMd/6cDl7Mg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "2"
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/intl-messageformat": {
+      "version": "10.7.7",
+      "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.7.tgz",
+      "integrity": "sha512-F134jIoeYMro/3I0h08D0Yt4N9o9pjddU/4IIxMMURqbAtI2wu70X8hvG1V48W49zXHXv3RKSF/po+0fDfsGjA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/fast-memoize": "2.2.3",
+        "@formatjs/icu-messageformat-parser": "2.9.4",
+        "tslib": "2"
+      }
+    },
+    "node_modules/@strapi/plugin-seo/node_modules/react-intl": {
+      "version": "6.8.9",
+      "resolved": "https://registry.npmjs.org/react-intl/-/react-intl-6.8.9.tgz",
+      "integrity": "sha512-TUfj5E7lyUDvz/GtovC9OMh441kBr08rtIbgh3p0R8iF3hVY+V2W9Am7rb8BpJ/29BH1utJOqOOhmvEVh3GfZg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@formatjs/ecma402-abstract": "2.2.4",
+        "@formatjs/icu-messageformat-parser": "2.9.4",
+        "@formatjs/intl": "2.10.15",
+        "@formatjs/intl-displaynames": "6.8.5",
+        "@formatjs/intl-listformat": "7.7.5",
+        "@types/hoist-non-react-statics": "3",
+        "@types/react": "16 || 17 || 18",
+        "hoist-non-react-statics": "3",
+        "intl-messageformat": "10.7.7",
+        "tslib": "2"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || 17 || 18",
+        "typescript": "^4.7 || 5"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@strapi/plugin-users-permissions": {
       "version": "5.11.0",
       "resolved": "https://registry.npmjs.org/@strapi/plugin-users-permissions/-/plugin-users-permissions-5.11.0.tgz",
@@ -7691,6 +7896,38 @@
       },
       "engines": {
         "node": ">=14.14"
+      }
+    },
+    "node_modules/@strapi/ui-primitives": {
+      "version": "2.0.0-rc.28",
+      "resolved": "https://registry.npmjs.org/@strapi/ui-primitives/-/ui-primitives-2.0.0-rc.28.tgz",
+      "integrity": "sha512-ZUbkilXhdWrz8sztKrniTar6ltCQooeFrtLTZWFyCE5WMK/ySJkMbjyoaECb4EOg9olA2CILEsysC4kgth1bgA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/number": "1.0.1",
+        "@radix-ui/primitive": "1.0.1",
+        "@radix-ui/react-collection": "1.0.3",
+        "@radix-ui/react-compose-refs": "1.0.1",
+        "@radix-ui/react-context": "1.0.1",
+        "@radix-ui/react-direction": "1.0.1",
+        "@radix-ui/react-dismissable-layer": "1.0.5",
+        "@radix-ui/react-focus-guards": "1.0.1",
+        "@radix-ui/react-focus-scope": "1.0.4",
+        "@radix-ui/react-id": "1.0.1",
+        "@radix-ui/react-popper": "1.1.3",
+        "@radix-ui/react-portal": "1.0.4",
+        "@radix-ui/react-primitive": "1.0.3",
+        "@radix-ui/react-slot": "1.0.2",
+        "@radix-ui/react-use-controllable-state": "1.0.1",
+        "@radix-ui/react-use-layout-effect": "1.0.1",
+        "@radix-ui/react-use-previous": "1.0.1",
+        "@radix-ui/react-visually-hidden": "1.0.3",
+        "aria-hidden": "1.2.4",
+        "react-remove-scroll": "2.5.10"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/@strapi/upload": {
@@ -19477,6 +19714,31 @@
         "jsonc-parser": "^3.2.0",
         "vscode-oniguruma": "^1.7.0",
         "vscode-textmate": "^8.0.0"
+      }
+    },
+    "node_modules/showdown": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/showdown/-/showdown-2.1.0.tgz",
+      "integrity": "sha512-/6NVYu4U819R2pUIk79n67SYgJHWCce0a5xTP979WbNp0FL9MN1I1QK662IDU1b6JzKTvmhgI7T7JYIxBi3kMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^9.0.0"
+      },
+      "bin": {
+        "showdown": "bin/showdown.js"
+      },
+      "funding": {
+        "type": "individual",
+        "url": "https://www.paypal.me/tiviesantos"
+      }
+    },
+    "node_modules/showdown/node_modules/commander": {
+      "version": "9.5.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-9.5.0.tgz",
+      "integrity": "sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || >=14"
       }
     },
     "node_modules/side-channel": {

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@aws-sdk/client-cognito-identity-provider": "^3.799.0",
     "@strapi/plugin-cloud": "5.11.0",
     "@strapi/plugin-documentation": "^5.13.0",
+    "@strapi/plugin-seo": "^2.0.8",
     "@strapi/plugin-users-permissions": "5.11.0",
     "@strapi/strapi": "5.11.0",
     "axios": "^1.9.0",

--- a/src/api/regular-page/content-types/regular-page/schema.json
+++ b/src/api/regular-page/content-types/regular-page/schema.json
@@ -31,6 +31,16 @@
     },
     "pageID": {
       "type": "uid"
+    },
+    "SEOSettings": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.seo"
+    },
+    "SocialSettings": {
+      "type": "component",
+      "repeatable": true,
+      "component": "shared.open-graph"
     }
   }
 }

--- a/src/components/shared/open-graph.json
+++ b/src/components/shared/open-graph.json
@@ -1,0 +1,35 @@
+{
+  "collectionName": "components_shared_open_graphs",
+  "info": {
+    "displayName": "openGraph",
+    "icon": "project-diagram"
+  },
+  "options": {},
+  "attributes": {
+    "ogTitle": {
+      "type": "string",
+      "required": true,
+      "maxLength": 70
+    },
+    "ogDescription": {
+      "type": "string",
+      "maxLength": 200,
+      "required": true
+    },
+    "ogImage": {
+      "allowedTypes": [
+        "images"
+      ],
+      "type": "media",
+      "multiple": false
+    },
+    "ogUrl": {
+      "type": "string",
+      "required": false
+    },
+    "ogType": {
+      "type": "string",
+      "required": false
+    }
+  }
+}

--- a/src/components/shared/seo.json
+++ b/src/components/shared/seo.json
@@ -1,0 +1,51 @@
+{
+  "collectionName": "components_shared_seos",
+  "info": {
+    "displayName": "seo",
+    "icon": "search"
+  },
+  "options": {},
+  "attributes": {
+    "metaTitle": {
+      "required": true,
+      "type": "string",
+      "maxLength": 60
+    },
+    "metaDescription": {
+      "type": "string",
+      "required": true,
+      "maxLength": 160,
+      "minLength": 50
+    },
+    "metaImage": {
+      "type": "media",
+      "multiple": false,
+      "required": false,
+      "allowedTypes": [
+        "images"
+      ]
+    },
+    "openGraph": {
+      "type": "component",
+      "repeatable": false,
+      "component": "shared.open-graph"
+    },
+    "keywords": {
+      "type": "text",
+      "regex": "[^,]+"
+    },
+    "metaRobots": {
+      "type": "string",
+      "regex": "[^,]+"
+    },
+    "metaViewport": {
+      "type": "string"
+    },
+    "canonicalURL": {
+      "type": "string"
+    },
+    "structuredData": {
+      "type": "json"
+    }
+  }
+}

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-07-09T18:12:39.147Z"
+    "x-generation-date": "2025-07-09T18:37:45.617Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -45774,6 +45774,15 @@
               "pageID": {
                 "type": "string"
               },
+              "SEOSettings": {
+                "$ref": "#/components/schemas/SharedSeoComponent"
+              },
+              "SocialSettings": {
+                "type": "array",
+                "items": {
+                  "$ref": "#/components/schemas/SharedOpenGraphComponent"
+                }
+              },
               "locale": {
                 "type": "string"
               },
@@ -45897,6 +45906,15 @@
           "pageID": {
             "type": "string"
           },
+          "SEOSettings": {
+            "$ref": "#/components/schemas/SharedSeoComponent"
+          },
+          "SocialSettings": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/SharedOpenGraphComponent"
+            }
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -46002,6 +46020,15 @@
                 },
                 "pageID": {
                   "type": "string"
+                },
+                "SEOSettings": {
+                  "$ref": "#/components/schemas/SharedSeoComponent"
+                },
+                "SocialSettings": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/SharedOpenGraphComponent"
+                  }
                 },
                 "createdAt": {
                   "type": "string",
@@ -47863,6 +47890,314 @@
           "Settings": {
             "$ref": "#/components/schemas/CommonComponentsModuleSettingsComponent"
           }
+        }
+      },
+      "SharedOpenGraphComponent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "ogTitle": {
+            "type": "string"
+          },
+          "ogDescription": {
+            "type": "string"
+          },
+          "ogImage": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "documentId": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "alternativeText": {
+                "type": "string"
+              },
+              "caption": {
+                "type": "string"
+              },
+              "width": {
+                "type": "integer"
+              },
+              "height": {
+                "type": "integer"
+              },
+              "formats": {},
+              "hash": {
+                "type": "string"
+              },
+              "ext": {
+                "type": "string"
+              },
+              "mime": {
+                "type": "string"
+              },
+              "size": {
+                "type": "number",
+                "format": "float"
+              },
+              "url": {
+                "type": "string"
+              },
+              "previewUrl": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "provider_metadata": {},
+              "related": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "folder": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "folderPath": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "publishedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "createdBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "updatedBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "locale": {
+                "type": "string"
+              },
+              "localizations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "ogUrl": {
+            "type": "string"
+          },
+          "ogType": {
+            "type": "string"
+          }
+        }
+      },
+      "SharedSeoComponent": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "number"
+          },
+          "metaTitle": {
+            "type": "string"
+          },
+          "metaDescription": {
+            "type": "string"
+          },
+          "metaImage": {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "number"
+              },
+              "documentId": {
+                "type": "string"
+              },
+              "name": {
+                "type": "string"
+              },
+              "alternativeText": {
+                "type": "string"
+              },
+              "caption": {
+                "type": "string"
+              },
+              "width": {
+                "type": "integer"
+              },
+              "height": {
+                "type": "integer"
+              },
+              "formats": {},
+              "hash": {
+                "type": "string"
+              },
+              "ext": {
+                "type": "string"
+              },
+              "mime": {
+                "type": "string"
+              },
+              "size": {
+                "type": "number",
+                "format": "float"
+              },
+              "url": {
+                "type": "string"
+              },
+              "previewUrl": {
+                "type": "string"
+              },
+              "provider": {
+                "type": "string"
+              },
+              "provider_metadata": {},
+              "related": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              },
+              "folder": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "folderPath": {
+                "type": "string"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "publishedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "createdBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "updatedBy": {
+                "type": "object",
+                "properties": {
+                  "id": {
+                    "type": "number"
+                  },
+                  "documentId": {
+                    "type": "string"
+                  }
+                }
+              },
+              "locale": {
+                "type": "string"
+              },
+              "localizations": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "id": {
+                      "type": "number"
+                    },
+                    "documentId": {
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "openGraph": {
+            "$ref": "#/components/schemas/SharedOpenGraphComponent"
+          },
+          "keywords": {
+            "type": "string"
+          },
+          "metaRobots": {
+            "type": "string"
+          },
+          "metaViewport": {
+            "type": "string"
+          },
+          "canonicalURL": {
+            "type": "string"
+          },
+          "structuredData": {}
         }
       },
       "SalutationRequest": {

--- a/types/generated/components.d.ts
+++ b/types/generated/components.d.ts
@@ -408,6 +408,57 @@ export interface RepeatableComponnetsTrackItemIconTitleDesc
   };
 }
 
+export interface SharedOpenGraph extends Struct.ComponentSchema {
+  collectionName: 'components_shared_open_graphs';
+  info: {
+    displayName: 'openGraph';
+    icon: 'project-diagram';
+  };
+  attributes: {
+    ogDescription: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 200;
+      }>;
+    ogImage: Schema.Attribute.Media<'images'>;
+    ogTitle: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 70;
+      }>;
+    ogType: Schema.Attribute.String;
+    ogUrl: Schema.Attribute.String;
+  };
+}
+
+export interface SharedSeo extends Struct.ComponentSchema {
+  collectionName: 'components_shared_seos';
+  info: {
+    displayName: 'seo';
+    icon: 'search';
+  };
+  attributes: {
+    canonicalURL: Schema.Attribute.String;
+    keywords: Schema.Attribute.Text;
+    metaDescription: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 160;
+        minLength: 50;
+      }>;
+    metaImage: Schema.Attribute.Media<'images'>;
+    metaRobots: Schema.Attribute.String;
+    metaTitle: Schema.Attribute.String &
+      Schema.Attribute.Required &
+      Schema.Attribute.SetMinMaxLength<{
+        maxLength: 60;
+      }>;
+    metaViewport: Schema.Attribute.String;
+    openGraph: Schema.Attribute.Component<'shared.open-graph', false>;
+    structuredData: Schema.Attribute.JSON;
+  };
+}
+
 declare module '@strapi/strapi' {
   export module Public {
     export interface ComponentSchemas {
@@ -435,6 +486,8 @@ declare module '@strapi/strapi' {
       'repeatable-componnets.icon-title-text': RepeatableComponnetsIconTitleText;
       'repeatable-componnets.title-icon-bg-image': RepeatableComponnetsTitleIconBgImage;
       'repeatable-componnets.track-item-icon-title-desc': RepeatableComponnetsTrackItemIconTitleDesc;
+      'shared.open-graph': SharedOpenGraph;
+      'shared.seo': SharedSeo;
     }
   }
 }

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1782,6 +1782,8 @@ export interface ApiRegularPageRegularPage extends Struct.CollectionTypeSchema {
       ]
     >;
     publishedAt: Schema.Attribute.DateTime;
+    SEOSettings: Schema.Attribute.Component<'shared.seo', false>;
+    SocialSettings: Schema.Attribute.Component<'shared.open-graph', true>;
     updatedAt: Schema.Attribute.DateTime;
     updatedBy: Schema.Attribute.Relation<'oneToOne', 'admin::user'> &
       Schema.Attribute.Private;


### PR DESCRIPTION
- Introduced SEOSettings and SocialSettings fields in the regular page schema to support SEO and Open Graph functionalities.
- Updated package.json and package-lock.json to include @strapi/plugin-seo version 2.0.8.
- Configured the SEO plugin in plugins.js to enable its functionality.
- Added corresponding component schemas for SharedSeo and SharedOpenGraph in TypeScript definitions.