### PR TITLE
Add hackathonName field to nabard-hackathon schema and TypeScript def…

### DIFF
--- a/src/api/nabard-hackathon/content-types/nabard-hackathon/schema.json
+++ b/src/api/nabard-hackathon/content-types/nabard-hackathon/schema.json
@@ -153,6 +153,9 @@
     },
     "prototypeAddressProblem": {
       "type": "string"
+    },
+    "hackathonName": {
+      "type": "string"
     }
   }
 }

--- a/src/extensions/documentation/documentation/1.0.0/full_documentation.json
+++ b/src/extensions/documentation/documentation/1.0.0/full_documentation.json
@@ -14,7 +14,7 @@
       "name": "Apache 2.0",
       "url": "https://www.apache.org/licenses/LICENSE-2.0.html"
     },
-    "x-generation-date": "2025-07-10T13:24:22.470Z"
+    "x-generation-date": "2025-07-10T13:35:58.365Z"
   },
   "x-strapi-config": {
     "plugins": [
@@ -35799,6 +35799,9 @@
               "prototypeAddressProblem": {
                 "type": "string"
               },
+              "hackathonName": {
+                "type": "string"
+              },
               "locale": {
                 "type": "string"
               },
@@ -36589,6 +36592,9 @@
           "prototypeAddressProblem": {
             "type": "string"
           },
+          "hackathonName": {
+            "type": "string"
+          },
           "createdAt": {
             "type": "string",
             "format": "date-time"
@@ -36891,6 +36897,9 @@
                   "type": "string"
                 },
                 "prototypeAddressProblem": {
+                  "type": "string"
+                },
+                "hackathonName": {
                   "type": "string"
                 },
                 "createdAt": {

--- a/types/generated/contentTypes.d.ts
+++ b/types/generated/contentTypes.d.ts
@@ -1164,6 +1164,7 @@ export interface ApiNabardHackathonNabardHackathon
     declarationAgreeRulesDecisions: Schema.Attribute.String;
     declarationInformationAccurate: Schema.Attribute.String;
     declarationPitchDate: Schema.Attribute.String;
+    hackathonName: Schema.Attribute.String;
     hackathonPartiDescription: Schema.Attribute.Text;
     hackathonPartiProblem: Schema.Attribute.String;
     hackathonPartiTechStack: Schema.Attribute.String;


### PR DESCRIPTION
…initions

- Introduced a new field, hackathonName, in schema.json and full_documentation.json.
- Updated TypeScript definitions to include the new hackathonName attribute.